### PR TITLE
feat: basic start/stop page and minecraft inventory components:

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,12 +3,8 @@ name: Backend CI
 on:
   push:
     branches: [main]
-    paths:
-      - backend/**
   pull_request:
     branches: [main]
-    paths:
-      - backend/**
 
 permissions:
   contents: read
@@ -18,8 +14,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - backend/**
+
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,6 +52,8 @@ jobs:
 
   build:
     name: Build
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -60,6 +73,8 @@ jobs:
 
   test:
     name: Tests
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,12 +3,8 @@ name: Frontend CI
 on:
   push:
     branches: [main]
-    paths:
-      - frontend/**
   pull_request:
     branches: [main]
-    paths:
-      - frontend/**
 
 permissions:
   contents: read
@@ -18,8 +14,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - frontend/**
+
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -37,6 +48,8 @@ jobs:
 
   build:
     name: Build
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Minecraft Dashboard</title>
+    <style>body { margin: 0; }</style>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
+import { McTooltipPortal } from "./components/minecraft-ui";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
         <Route path="/" element={<Login />} />
         <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
+      <McTooltipPortal />
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/minecraft-ui/InvGrid.tsx
+++ b/frontend/src/components/minecraft-ui/InvGrid.tsx
@@ -1,0 +1,30 @@
+import InvSlot from "./InvSlot";
+import "./minecraft-ui.css";
+
+export interface InvGridProps {
+  rows: number;
+  cols: number;
+  items?: (string | null)[];
+  className?: string;
+}
+
+export default function InvGrid({ rows, cols, items, className }: InvGridProps) {
+  const totalSlots = rows * cols;
+  const grid: (string | null)[] = [];
+  for (let i = 0; i < totalSlots; i++) {
+    grid.push(items?.[i] ?? null);
+  }
+
+  return (
+    <div className={`mcui ${className ?? ""}`}>
+      {Array.from({ length: rows }, (_, row) => (
+        <div key={row} className="mcui-row">
+          {Array.from({ length: cols }, (_, col) => {
+            const idx = row * cols + col;
+            return <InvSlot key={idx} item={grid[idx]} />;
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/minecraft-ui/InvSlot.tsx
+++ b/frontend/src/components/minecraft-ui/InvSlot.tsx
@@ -1,4 +1,4 @@
-import { showTooltip, moveTooltip, hideTooltip } from "./McTooltip";
+import { showTooltip, moveTooltip, hideTooltip } from "./McTooltipController";
 import "./minecraft-ui.css";
 
 export interface InvSlotProps {

--- a/frontend/src/components/minecraft-ui/InvSlot.tsx
+++ b/frontend/src/components/minecraft-ui/InvSlot.tsx
@@ -1,0 +1,39 @@
+import { showTooltip, moveTooltip, hideTooltip } from "./McTooltip";
+import "./minecraft-ui.css";
+
+export interface InvSlotProps {
+  item?: string | null;
+  className?: string;
+}
+
+function itemDisplayName(item: string): string {
+  return item.replace(/_/g, " ");
+}
+
+function itemImageUrl(item: string): string {
+  return `https://minecraft.wiki/images/Invicon_${item}.png`;
+}
+
+export default function InvSlot({ item, className }: InvSlotProps) {
+  return (
+    <span className={`invslot ${className ?? ""}`}>
+      {item && (
+        <span
+          className="invslot-item"
+          onMouseEnter={(e) =>
+            showTooltip(itemDisplayName(item), e.clientX, e.clientY)
+          }
+          onMouseMove={(e) => moveTooltip(e.clientX, e.clientY)}
+          onMouseLeave={hideTooltip}
+        >
+          <img
+            src={itemImageUrl(item)}
+            alt={itemDisplayName(item)}
+            className="invslot-item-image"
+            draggable={false}
+          />
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/minecraft-ui/InvSlot.tsx
+++ b/frontend/src/components/minecraft-ui/InvSlot.tsx
@@ -1,4 +1,4 @@
-import { showTooltip, moveTooltip, hideTooltip } from "./McTooltipController";
+import { tooltipController } from "./McTooltipController";
 import "./minecraft-ui.css";
 
 export interface InvSlotProps {
@@ -21,10 +21,10 @@ export default function InvSlot({ item, className }: InvSlotProps) {
         <span
           className="invslot-item"
           onMouseEnter={(e) =>
-            showTooltip(itemDisplayName(item), e.clientX, e.clientY)
+            tooltipController.show(itemDisplayName(item), e.clientX, e.clientY)
           }
-          onMouseMove={(e) => moveTooltip(e.clientX, e.clientY)}
-          onMouseLeave={hideTooltip}
+          onMouseMove={(e) => tooltipController.move(e.clientX, e.clientY)}
+          onMouseLeave={tooltipController.hide}
         >
           <img
             src={itemImageUrl(item)}

--- a/frontend/src/components/minecraft-ui/McButton.tsx
+++ b/frontend/src/components/minecraft-ui/McButton.tsx
@@ -1,0 +1,13 @@
+import "./minecraft-ui.css";
+
+interface McButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export default function McButton({ children, className, ...props }: McButtonProps) {
+  return (
+    <button className={`mc-btn ${className ?? ""}`} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/minecraft-ui/McTooltip.tsx
+++ b/frontend/src/components/minecraft-ui/McTooltip.tsx
@@ -1,36 +1,15 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { bindTooltipSetter, type TooltipState } from "./McTooltipController";
 import "./minecraft-ui.css";
-
-interface TooltipState {
-  text: string;
-  x: number;
-  y: number;
-}
-
-type SetTooltip = React.Dispatch<React.SetStateAction<TooltipState | null>>;
-
-let setGlobalTooltip: SetTooltip | null = null;
-
-export function showTooltip(text: string, x: number, y: number) {
-  setGlobalTooltip?.({ text, x, y });
-}
-
-export function moveTooltip(x: number, y: number) {
-  setGlobalTooltip?.((prev) => (prev ? { ...prev, x, y } : null));
-}
-
-export function hideTooltip() {
-  setGlobalTooltip?.(null);
-}
 
 export default function McTooltipPortal() {
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
   useEffect(() => {
-    setGlobalTooltip = setTooltip;
+    bindTooltipSetter(setTooltip);
     return () => {
-      setGlobalTooltip = null;
+      bindTooltipSetter(null);
     };
   }, []);
 

--- a/frontend/src/components/minecraft-ui/McTooltip.tsx
+++ b/frontend/src/components/minecraft-ui/McTooltip.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import "./minecraft-ui.css";
+
+interface TooltipState {
+  text: string;
+  x: number;
+  y: number;
+}
+
+type SetTooltip = React.Dispatch<React.SetStateAction<TooltipState | null>>;
+
+let setGlobalTooltip: SetTooltip | null = null;
+
+export function showTooltip(text: string, x: number, y: number) {
+  setGlobalTooltip?.({ text, x, y });
+}
+
+export function moveTooltip(x: number, y: number) {
+  setGlobalTooltip?.((prev) => (prev ? { ...prev, x, y } : null));
+}
+
+export function hideTooltip() {
+  setGlobalTooltip?.(null);
+}
+
+export default function McTooltipPortal() {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+  useEffect(() => {
+    setGlobalTooltip = setTooltip;
+    return () => {
+      setGlobalTooltip = null;
+    };
+  }, []);
+
+  if (!tooltip) return null;
+
+  return createPortal(
+    <div
+      className="mc-tooltip"
+      style={{
+        left: tooltip.x + 12,
+        top: tooltip.y - 12,
+        transform: "translateY(-100%)",
+      }}
+    >
+      {tooltip.text}
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/minecraft-ui/McTooltip.tsx
+++ b/frontend/src/components/minecraft-ui/McTooltip.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { bindTooltipSetter, type TooltipState } from "./McTooltipController";
+import { tooltipController, type TooltipState } from "./McTooltipController";
 import "./minecraft-ui.css";
 
 export default function McTooltipPortal() {
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
   useEffect(() => {
-    bindTooltipSetter(setTooltip);
+    tooltipController.bind(setTooltip);
     return () => {
-      bindTooltipSetter(null);
+      tooltipController.bind(null);
     };
   }, []);
 
@@ -21,7 +21,6 @@ export default function McTooltipPortal() {
       style={{
         left: tooltip.x + 12,
         top: tooltip.y - 12,
-        transform: "translateY(-100%)",
       }}
     >
       {tooltip.text}

--- a/frontend/src/components/minecraft-ui/McTooltipController.ts
+++ b/frontend/src/components/minecraft-ui/McTooltipController.ts
@@ -1,0 +1,27 @@
+import type { Dispatch, SetStateAction } from "react";
+
+export interface TooltipState {
+  text: string;
+  x: number;
+  y: number;
+}
+
+type SetTooltip = Dispatch<SetStateAction<TooltipState | null>>;
+
+let setGlobalTooltip: SetTooltip | null = null;
+
+export function bindTooltipSetter(setter: SetTooltip | null) {
+  setGlobalTooltip = setter;
+}
+
+export function showTooltip(text: string, x: number, y: number) {
+  setGlobalTooltip?.({ text, x, y });
+}
+
+export function moveTooltip(x: number, y: number) {
+  setGlobalTooltip?.((prev) => (prev ? { ...prev, x, y } : null));
+}
+
+export function hideTooltip() {
+  setGlobalTooltip?.(null);
+}

--- a/frontend/src/components/minecraft-ui/McTooltipController.ts
+++ b/frontend/src/components/minecraft-ui/McTooltipController.ts
@@ -8,20 +8,26 @@ export interface TooltipState {
 
 type SetTooltip = Dispatch<SetStateAction<TooltipState | null>>;
 
-let setGlobalTooltip: SetTooltip | null = null;
+class TooltipController {
+  private setter: SetTooltip | null = null;
 
-export function bindTooltipSetter(setter: SetTooltip | null) {
-  setGlobalTooltip = setter;
+  // Arrow fields so methods stay bound when passed as event handlers
+  // (e.g. onMouseLeave={tooltipController.hide}).
+  bind = (setter: SetTooltip | null) => {
+    this.setter = setter;
+  };
+
+  show = (text: string, x: number, y: number) => {
+    this.setter?.({ text, x, y });
+  };
+
+  move = (x: number, y: number) => {
+    this.setter?.((prev) => (prev ? { ...prev, x, y } : null));
+  };
+
+  hide = () => {
+    this.setter?.(null);
+  };
 }
 
-export function showTooltip(text: string, x: number, y: number) {
-  setGlobalTooltip?.({ text, x, y });
-}
-
-export function moveTooltip(x: number, y: number) {
-  setGlobalTooltip?.((prev) => (prev ? { ...prev, x, y } : null));
-}
-
-export function hideTooltip() {
-  setGlobalTooltip?.(null);
-}
+export const tooltipController = new TooltipController();

--- a/frontend/src/components/minecraft-ui/index.ts
+++ b/frontend/src/components/minecraft-ui/index.ts
@@ -1,0 +1,6 @@
+export { default as InvSlot } from "./InvSlot";
+export { default as InvGrid } from "./InvGrid";
+export { default as McButton } from "./McButton";
+export { default as McTooltipPortal } from "./McTooltip";
+export type { InvSlotProps } from "./InvSlot";
+export type { InvGridProps } from "./InvGrid";

--- a/frontend/src/components/minecraft-ui/minecraft-ui.css
+++ b/frontend/src/components/minecraft-ui/minecraft-ui.css
@@ -1,0 +1,246 @@
+/* ── Minecraft Font ── */
+@font-face {
+  font-family: Minecraft;
+  src:
+    url("https://minecraft.wiki/images/Minecraft.woff2?edfbc") format("woff2"),
+    url("https://minecraft.wiki/images/Minecraft.woff?ade8a") format("woff");
+}
+
+/* ── Page Background ── */
+
+.mc-page {
+  min-height: 100vh;
+  background-color: #593D29;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
+    url("https://minecraft.wiki/images/Dirt_(texture)_JE2_BE2.png");
+  background-size: auto, 64px 64px;
+  image-rendering: pixelated;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 96px 16px 32px;
+  gap: 24px;
+  position: relative;
+}
+
+/* Grass strip across the top */
+.mc-page::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
+    url("https://minecraft.wiki/images/Grass_Block_(side_texture)_JE2_BE2.png");
+  background-size: auto, 64px 64px;
+  image-rendering: pixelated;
+  pointer-events: none;
+}
+
+/* ── Minecraft Button ── */
+/* Uses the actual widget button textures from the game */
+
+.mc-btn {
+  display: inline-block;
+  position: relative;
+  min-width: 150px;
+  height: 40px;
+  padding: 0 16px;
+  border: 2px solid;
+  border-color: #dbdbdb #5b5b5b #5b5b5b #dbdbdb;
+  background-color: #8b8b8b;
+  border-image: url("https://minecraft.wiki/images/Widget_button.png") 4 fill / 4px / 0 stretch;
+  color: #e0e0e0;
+  font-family: Minecraft, sans-serif;
+  font-size: 16px;
+  text-shadow: 2px 2px 0 #3f3f3f;
+  cursor: pointer;
+  image-rendering: pixelated;
+  white-space: nowrap;
+  line-height: 36px;
+}
+
+.mc-btn:hover {
+  border-image-source: url("https://minecraft.wiki/images/Widget_button_highlighted.png");
+  color: #ffffa0;
+}
+
+.mc-btn:active {
+  border-image-source: url("https://minecraft.wiki/images/Widget_button.png");
+  color: #c0c0c0;
+}
+
+.mc-btn:disabled {
+  border-image-source: url("https://minecraft.wiki/images/Widget_button_disabled.png");
+  color: #6a6a6a;
+  text-shadow: 2px 2px 0 #1e1e1e;
+  cursor: not-allowed;
+}
+
+/* ── Panel Container (for grouping UI elements) ── */
+
+.mc-panel {
+  background-color: #c6c6c6;
+  border: 2px solid;
+  border-color: #dbdbdb #5b5b5b #5b5b5b #dbdbdb;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.mc-panel-title {
+  font-family: Minecraft, sans-serif;
+  font-size: 16px;
+  color: #404040;
+  margin-bottom: 4px;
+}
+
+/* ── Status Text ── */
+
+.mc-status {
+  font-family: Minecraft, sans-serif;
+  font-size: 16px;
+  color: #ffff55;
+  text-shadow: 2px 2px 0 #3f3f15;
+}
+
+/* ── Page Title ── */
+
+.mc-title {
+  font-family: Minecraft, sans-serif;
+  font-size: 32px;
+  color: #fff;
+  text-shadow: 3px 3px 0 #3f3f3f;
+  text-align: center;
+}
+
+/* ── Inventory Slot ── */
+/* Exact styles from https://minecraft.wiki */
+
+.invslot {
+  position: relative;
+  display: inline-block;
+  background: #8b8b8b no-repeat center center / 32px 32px;
+  border: 2px solid;
+  border-color: #373737 #fff #fff #373737;
+  width: 32px;
+  height: 32px;
+  font-size: 16px;
+  line-height: 1;
+  text-align: left;
+  vertical-align: bottom;
+  image-rendering: pixelated;
+}
+
+/* Corner pixel patches to complete the beveled look */
+.invslot::before,
+.invslot::after {
+  content: "";
+  position: absolute;
+  background-color: #8b8b8b;
+  height: 2px;
+  width: 2px;
+  pointer-events: none;
+}
+
+.invslot::before {
+  bottom: -2px;
+  left: -2px;
+}
+
+.invslot::after {
+  top: -2px;
+  right: -2px;
+}
+
+/* ── Slot Item ── */
+
+.invslot-item {
+  position: relative;
+  display: block;
+  margin: -2px;
+  padding: 2px;
+  width: 32px;
+  height: 32px;
+}
+
+.invslot-item-image {
+  display: block;
+  width: 32px;
+  height: 32px;
+  image-rendering: pixelated;
+  pointer-events: none;
+}
+
+.invslot-item:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+/* ── Cursor-following Tooltip ── */
+/* Exact styles from https://minecraft.wiki site.styles #minetip-tooltip */
+
+.mc-tooltip {
+  position: fixed;
+  background-color: rgba(16, 0, 16, 0.94);
+  color: #fbfbfb;
+  padding: 0.375em;
+  font-family: Minecraft, sans-serif;
+  font-size: 16px;
+  word-spacing: 4px;
+  white-space: nowrap;
+  line-height: 1.25em;
+  pointer-events: none;
+  z-index: 9999;
+  text-shadow: 0.125em 0.125em 0 #3e3e3e;
+}
+
+/* Dark side-borders that extend outward, inset from top/bottom (corner gap) */
+.mc-tooltip::before {
+  content: "";
+  position: absolute;
+  top: 0.125em;
+  right: -0.125em;
+  bottom: 0.125em;
+  left: -0.125em;
+  border: 0.15em solid rgba(16, 0, 16, 0.94);
+  border-style: none solid;
+}
+
+/* Purple gradient inner border, also inset from top/bottom (corner gap) */
+.mc-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 0.125em;
+  right: 0;
+  bottom: 0.125em;
+  left: 0;
+  border: 0.125em solid #2d0a63;
+  border-image: linear-gradient(
+    rgba(80, 0, 255, 0.31),
+    rgba(40, 0, 127, 0.31)
+  ) 1;
+}
+
+/* ── MCUI Container ── */
+
+.mcui {
+  display: inline-block;
+  position: relative;
+  background-color: #c6c6c6;
+  border: 2px solid;
+  border-color: #dbdbdb #5b5b5b #5b5b5b #dbdbdb;
+  padding: 6px;
+  text-align: left;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
+.mcui-row {
+  display: block;
+  font-size: 0; /* collapse whitespace between inline-block slots */
+}

--- a/frontend/src/components/minecraft-ui/minecraft-ui.css
+++ b/frontend/src/components/minecraft-ui/minecraft-ui.css
@@ -186,6 +186,7 @@
 
 .mc-tooltip {
   position: fixed;
+  transform: translateY(-100%);
   background-color: rgba(16, 0, 16, 0.94);
   color: #fbfbfb;
   padding: 0.375em;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,19 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../hooks/useAuth";
 import { API_BASE_URL } from "../libs/api";
+import { InvGrid, McButton } from "../components/minecraft-ui";
+
+const DEMO_ITEMS: (string | null)[] = [
+  "Diamond_Helmet",    "Diamond_Chestplate", "Diamond_Leggings",
+  "Diamond_Boots",     "Shield",             "Bow",
+  "Arrow",             "Golden_Apple",       "Ender_Pearl",
+  "Diamond_Sword",     "Diamond_Pickaxe",    "Diamond_Axe",
+  "Torch",             "Cobblestone",         "Oak_Planks",
+  "Bread",             "Cooked_Beef",              "Water_Bucket",
+  "Iron_Ingot",        "Gold_Ingot",         "Redstone",
+  "Lapis_Lazuli",      "Coal",               "Emerald",
+  "String",            "Bone",               "Gunpowder",
+];
 
 export default function Dashboard() {
   const { user, loading } = useAuth();
@@ -14,10 +27,6 @@ export default function Dashboard() {
     }
   }, [user, loading, navigate]);
 
-  useEffect(() => {
-    console.log(status);
-  }, [status])
-
   const handleStart = async () => {
     setStatus(null);
     try {
@@ -25,12 +34,10 @@ export default function Dashboard() {
         method: "POST",
         credentials: "include",
       });
-      console.log(res);
       const text = await res.text();
       const data = text ? JSON.parse(text) : {};
       setStatus(res.ok ? data.message ?? "Server started" : data.error ?? "Failed to start server");
     } catch (error) {
-      console.log(error);
       setStatus("Request failed with error: " + error);
     }
   };
@@ -42,12 +49,10 @@ export default function Dashboard() {
         method: "POST",
         credentials: "include",
       });
-      console.log(res);
       const text = await res.text();
       const data = text ? JSON.parse(text) : {};
       setStatus(res.ok ? data.message ?? "Server stopped" : data.error ?? "Failed to stop server");
     } catch (error) {
-      console.log(error);
       setStatus("Request failed with error: " + error);
     }
   };
@@ -55,10 +60,20 @@ export default function Dashboard() {
   if (loading) return null;
 
   return (
-    <div>
-      <button onClick={handleStart}>Start Server</button>
-      <button onClick={handleStop}>Stop Server</button>
-      {status && <p>{status}</p>}
+    <div className="mc-page">
+      <h1 className="mc-title">Kraft Bois</h1>
+
+      <div style={{ display: "flex", gap: 12 }}>
+        <McButton onClick={handleStart}>Start Server</McButton>
+        <McButton onClick={handleStop}>Stop Server</McButton>
+      </div>
+
+      {status && <p className="mc-status">{status}</p>}
+
+      <div className="mc-panel">
+        <span className="mc-panel-title">Inventory</span>
+        <InvGrid rows={3} cols={9} items={DEMO_ITEMS} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,9 @@ import { useAuth } from "../hooks/useAuth";
 import { API_BASE_URL } from "../libs/api";
 import { InvGrid, McButton } from "../components/minecraft-ui";
 
+// TODO: Temporary placeholder data. Will be replaced with live inventory
+// fetched from the backend (typed at the API boundary), at which point these
+// hardcoded item IDs go away.
 const DEMO_ITEMS: (string | null)[] = [
   "Diamond_Helmet",    "Diamond_Chestplate", "Diamond_Leggings",
   "Diamond_Boots",     "Shield",             "Bow",


### PR DESCRIPTION
## Summary  
- Built a reusable Minecraft UI component library (`frontend/src/components/minecraft-ui/`) that pixel-perfectly replicates the Minecraft  Wiki's inventory styling
- `InvSlot`: Single inventory slot with beveled borders, hover highlight, and cursor-following tooltip
- `InvGrid`: Composable `n * m` grid of slots, usable for any Minecraft UI (crafting table 3x3, chest 9x3, inventory 9x4, etc.)               
- `McButton`: Minecraft-styled button using the actual in-game `Widget_button.png` textures with hover/active/disabled states               
- `McTooltipPortal`: Global cursor-following tooltip with the Minecraft gradient purple border, corner insets, and Minecraft font (loaded from wiki's woff2)
- Restyled the Dashboard page with a tiling dirt background, Minecraft-font title, styled server Start/Stop buttons, and a 9x3 demo inventory panel

<img width="1728" height="852" alt="Screenshot 2026-03-05 at 8 39 16 PM" src="https://github.com/user-attachments/assets/aa8d1395-cb25-427b-a3ce-ff7ede44d535" />

This page will change greatly, I just wanted to get something started 